### PR TITLE
Increase the maximum file upload size

### DIFF
--- a/files/nginx/nginx.conf
+++ b/files/nginx/nginx.conf
@@ -52,6 +52,7 @@ http {
             etag on;
         }
 
+        client_max_body_size 32M;
         gzip on;
         gzip_comp_level 3;
         gzip_disable "msie6";


### PR DESCRIPTION
According to https://github.com/kanboard/kanboard/issues/1829 there is a severe limitation on the upload size of attachments in kanboard tasks.

That particular PR has been merged but the `client_max_body_size 32M;` stanza is **not** present in the latest `1.0.47` version of kanboard when you use the docker image.

Assuming this is the repo on which the `Dockefile` on kanboard/kanboard is being built upon, you have to include the proposed changes.

Otherwise, us, kanboard docker users, can only use attachments up to 1MB only...